### PR TITLE
Execute go commands in subshell w/ repo working directory

### DIFF
--- a/src/mpExperienceQUIC.py
+++ b/src/mpExperienceQUIC.py
@@ -7,8 +7,11 @@ class MpExperienceQUIC(MpExperience):
 	GO_BIN = "/usr/local/go/bin/go"
 	SERVER_LOG = "quic_server.log"
 	CLIENT_LOG = "quic_client.log"
+        GO_REPO_PATH = "~/go/src/github.com/lucas-clemente/quic-go/"
 	CLIENT_GO_FILE = "~/go/src/github.com/lucas-clemente/quic-go/example/client_benchmarker/main.go"
+	CLIENT_GO_FILE_RELATIVE = "example/client_benchmarker/main.go"
 	SERVER_GO_FILE = "~/go/src/github.com/lucas-clemente/quic-go/example/main.go"
+	SERVER_GO_FILE_RELATIVE = "example/main.go"
 	CERTPATH = "~/go/src/github.com/lucas-clemente/quic-go/example/"
 	PING_OUTPUT = "ping.log"
 
@@ -76,10 +79,14 @@ class MpExperienceQUIC(MpExperience):
 		return s
 
 	def compileGoFiles(self):
-		cmd = MpExperienceQUIC.GO_BIN + " build " + MpExperienceQUIC.SERVER_GO_FILE
+                cmd = "(cd " +  MpExperienceQUIC.GO_REPO_PATH + " && "
+		cmd += MpExperienceQUIC.GO_BIN + " build " + " -o /mnt/tmpfs/server_main " + MpExperienceQUIC.SERVER_GO_FILE_RELATIVE
+                cmd += ")"
 		self.mpTopo.commandTo(self.mpConfig.server, cmd)
-		self.mpTopo.commandTo(self.mpConfig.server, "mv main server_main")
-		cmd = MpExperienceQUIC.GO_BIN + " build " + MpExperienceQUIC.CLIENT_GO_FILE
+
+                cmd = "(cd " +  MpExperienceQUIC.GO_REPO_PATH + " && "
+		cmd = MpExperienceQUIC.GO_BIN + " build " + " -o /mnt/tmpfs/main " + MpExperienceQUIC.CLIENT_GO_FILE_RELATIVE
+                cmd +=  ")"
 		self.mpTopo.commandTo(self.mpConfig.server, cmd)
 
 	def clean(self):
@@ -105,7 +112,7 @@ class MpExperienceQUIC(MpExperience):
 		self.mpTopo.commandTo(self.mpConfig.server, "netstat -sn > netstat_server_after")
 		self.mpTopo.commandTo(self.mpConfig.client, "netstat -sn > netstat_client_after")
 
-		self.mpTopo.commandTo(self.mpConfig.server, "pkill -f " + MpExperienceQUIC.SERVER_GO_FILE)
+		self.mpTopo.commandTo(self.mpConfig.server, "pkill -f " + MpExperienceQUIC.SERVER_GO_FILE_RELATIVE)
 
 		self.mpTopo.commandTo(self.mpConfig.client, "sleep 2")
 		# Need to delete the go-build directory in tmp; could lead to no more space left error

--- a/src/mpExperienceQUICReqres.py
+++ b/src/mpExperienceQUICReqres.py
@@ -5,10 +5,13 @@ import os
 
 class MpExperienceQUICReqres(MpExperience):
 	GO_BIN = "/usr/local/go/bin/go"
-	SERVER_LOG = "quic_server.log"
-	CLIENT_LOG = "quic_client.log"
+	SERVER_LOG = "/mnt/tmpfs/quic_server.log"
+	CLIENT_LOG = "/mnt/tmpfs/quic_client.log"
+        GO_REPO_PATH = "~/go/src/github.com/lucas-clemente/quic-go/"
 	CLIENT_GO_FILE = "~/go/src/github.com/lucas-clemente/quic-go/example/reqres/client/reqres.go"
+	CLIENT_GO_FILE_RELATIVE = "example/reqres/client/reqres.go"
 	SERVER_GO_FILE = "~/go/src/github.com/lucas-clemente/quic-go/example/reqres/reqres.go"
+	SERVER_GO_FILE_RELATIVE = "example/reqres/reqres.go"
 	PING_OUTPUT = "ping.log"
 
 	def __init__(self, xpParamFile, mpTopo, mpConfig):
@@ -47,17 +50,21 @@ class MpExperienceQUICReqres(MpExperience):
 				MpExperienceQUICReqres.SERVER_LOG )
 
 	def getQUICReqresServerCmd(self):
-		s = MpExperienceQUICReqres.GO_BIN + " run " + MpExperienceQUICReqres.SERVER_GO_FILE
+                s = "(cd " +  MpExperienceQUICReqres.GO_REPO_PATH + " && "
+		s += MpExperienceQUICReqres.GO_BIN + " run " + MpExperienceQUICReqres.SERVER_GO_FILE_RELATIVE
 		s += " -addr 0.0.0.0:8080 &>" + MpExperienceQUICReqres.SERVER_LOG + " &"
+                s += ")"
 		print(s)
 		return s
 
 	def getQUICReqresClientCmd(self):
-		s = MpExperienceQUICReqres.GO_BIN + " run " + MpExperienceQUICReqres.CLIENT_GO_FILE
+                s = "(cd " +  MpExperienceQUICReqres.GO_REPO_PATH + " && "
+		s += MpExperienceQUICReqres.GO_BIN + " run " + MpExperienceQUICReqres.CLIENT_GO_FILE_RELATIVE
 		s += " -addr " + self.mpConfig.getServerIP() + ":8080 -runTime " + self.run_time + "s"
 		if int(self.multipath) > 0:
 			s += " -m"
 		s += " &>" + MpExperienceQUICReqres.CLIENT_LOG
+                s += ")"
 		print(s)
 		return s
 


### PR DESCRIPTION
Versions of golang centered around modules require the context of the module files to build or run golang programs. Running from the working directory of the scripts fails for newer versions of golang.

By running the go commands (build for Quic, and run for QuicReqres) in a subshell the working directory of the script is preserved and the module files can be properly accessed.

This solution works for golang 1.17.7  and should be backwards compatible to 1.9.2+ which the original artifacts use (_should_ because packages don't compile properly on 1.9.2 anymore). 